### PR TITLE
Update Log4j 2 to 2.15.0 for CVE-2021-44228, related to previous comm…

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -166,10 +166,10 @@ dependencies {
 
     // SLF4J, Log4j 2 (note Log4j 2 is used by various libraries, best not to replace it even if mostly possible with SLF4J)
     compile 'org.slf4j:slf4j-api:1.7.32'
-    compile 'org.apache.logging.log4j:log4j-core:2.14.1'
-    compile 'org.apache.logging.log4j:log4j-api:2.14.1'
-    runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.1'
-    runtime 'org.apache.logging.log4j:log4j-jcl:2.14.1'
+    compile 'org.apache.logging.log4j:log4j-core:2.15.0'
+    compile 'org.apache.logging.log4j:log4j-api:2.15.0'
+    runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
+    runtime 'org.apache.logging.log4j:log4j-jcl:2.15.0'
 
     // SubEtha SMTP (module as depends on old javax.mail location; also uses SLF4J, activation included elsewhere)
     compile module('org.subethamail:subethasmtp:3.1.7')


### PR DESCRIPTION
…it adding disable setting to log4j2.xml config file; from general testing logging still all working, including log feed to ElasticSearch